### PR TITLE
Set notification more intelligently

### DIFF
--- a/app/src/main/java/com/scratchdevs/ecodigify/MainActivity.kt
+++ b/app/src/main/java/com/scratchdevs/ecodigify/MainActivity.kt
@@ -6,7 +6,9 @@ import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupWithNavController
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.scratchdevs.ecodigify.databinding.ActivityMainBinding
+import com.scratchdevs.ecodigify.dataclass.Ingredient
 import com.scratchdevs.ecodigify.notifications.NotificationScheduler
+import java.time.LocalDate
 
 /**
  * Main activity of the application.
@@ -33,9 +35,15 @@ class MainActivity : androidx.appcompat.app.AppCompatActivity() {
         Manager.init(applicationContext)
 
         run(lifecycle, {
-            val notificationScheduler =
-                NotificationScheduler(applicationContext)
-            notificationScheduler.setExpireNotificationForEach(Manager.ingredientGetAll())
+            val notificationScheduler = NotificationScheduler(applicationContext)
+            Manager.ingredientGetAll().forEach { ingredient ->
+                val notified = notificationScheduler.setExpireNotificationFor(ingredient)
+                if (notified) {
+                    val newIngredient = ingredient.copy(lastNotified = LocalDate.now())
+                    Manager.ingredientRemove(ingredient)
+                    Manager.ingredientAdd(newIngredient)
+                }
+            }
         })
 
         binding = ActivityMainBinding.inflate(layoutInflater)

--- a/app/src/main/java/com/scratchdevs/ecodigify/dataclass/Ingredient.kt
+++ b/app/src/main/java/com/scratchdevs/ecodigify/dataclass/Ingredient.kt
@@ -75,7 +75,10 @@ data class Ingredient(
     @Serializable(with = LocalDateSerializer::class)
     @ColumnInfo(name = "expiration_date")
     val expirationDate: LocalDate,
+    val quantity: String,
     @ColumnInfo(name = "possible_names")
-    var possibleNames: List<String>,
-    val quantity: String
+    var possibleNames: List<String> = emptyList(),
+    @Serializable(with = LocalDateSerializer::class)
+    @ColumnInfo(name = "last_notified")
+    val lastNotified: LocalDate? = null,
 ) : Parcelable


### PR DESCRIPTION
## Summary

Questo PR cerca di settare le notifiche di scadenza per un prodotto nel modo più intelligente possibile.

## Additional Tests

- [x] Testing on OnePlus Phone (@Friedchicken-42, @LucaBarban)
- [x] Aggiorna documentazione per mettere che mettiamo una notifica per la scadenza di un prodotto 7 giorni prima invece che 2 giorni prima (@LucaBarban).
